### PR TITLE
Revert Python image version to 3.8.5

### DIFF
--- a/images/evkk-stanza.Dockerfile
+++ b/images/evkk-stanza.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.2
+FROM python:3.8.5
 RUN apt-get update && apt-get install -y libjsoncpp-dev hfst && apt-get clean
 RUN pip install stanza
 RUN python -c "import stanza; stanza.download('et'); stanza.download('ru');"


### PR DESCRIPTION
Ühelgi uuemal versioonil uus silbitaja hetkel tööle ei hakka