### PR TITLE
ELLE-297 | Black box bug on download

### DIFF
--- a/ui/src/elle/tools/correction/util/Utils.js
+++ b/ui/src/elle/tools/correction/util/Utils.js
@@ -104,7 +104,7 @@ export const parseHtmlForDocx = (htmlString, type) => {
         colorClass = node.className || null;
       }
 
-      if (type === GRAMMAR) {
+      if (type === GRAMMAR && Object.keys(correctorDocxColors).includes(colorClass)) {
         result.push(
           new Bookmark({
             id: node.id,


### PR DESCRIPTION
Eemaldasin bugi, kus sõna paranduse vastuvõtmisel või keeldumisel ilmus sõna ümber must kast.