### PR TITLE
fix: stanza server 500 errors on text analysis endpoint

### DIFF
--- a/stanza-server/corrector_functions.py
+++ b/stanza-server/corrector_functions.py
@@ -312,6 +312,12 @@ def merge_corrections(processed_corrections, list_checked_spelling_errors):
 
 
 def generate_grammar_output(input_text, corrections, list_checked_spelling_errors=None):
+    if corrections is None:
+        return {
+            "corrector_results": [{"corrected": False, "text": input_text, "error_id": "0_unmarked"}],
+            "error_list": {},
+            "error_count": 0
+        }
     processed_corrections = process_corrections(corrections['corrections'])
     sorted_corrections = merge_corrections(processed_corrections, list_checked_spelling_errors)
 
@@ -406,6 +412,8 @@ def calculate_content_word(lemmas, word_types):
 def calculate_abstract_words(abstract_answer, word_types):
     abstract_count = 0
     for index, word in enumerate(abstract_answer):
+        if index >= len(word_types):
+            break
         if (word.get("abstractness") == 3
             and word_types[index] != PROPN
             and word_types[index] == NOUN):
@@ -431,6 +439,8 @@ def handle_uncommon_words_marking(text, word_types, lemmas, words):
 def handle_abstract_words_marking(text, abstract_answer, word_types, words):
     temp_text = replace_combined.sub('', text)
     for index, word in enumerate(abstract_answer):
+        if index >= len(word_types):
+            break
         if word['abstractness'] == 3 and word_types[index] != PROPN and \
             word_types[index] == NOUN:
             new_word = f'<span class="abstract-word-color">{words[index]}</span>'

--- a/stanza-server/grammar_fetches.py
+++ b/stanza-server/grammar_fetches.py
@@ -13,25 +13,25 @@ test_grammar_url = 'https://api.tartunlp.ai/grammar/v2'
 # TODO: add back grammar_url implementation when response parsing has been fixed
 def fetch_grammar(text):
     data = {data_text: text}
-    try:
-        response = requests.post(grammar_alt_url, headers=headers, json=data, timeout=10)
-        if response.status_code == 200:
-            return response.json()
-        else:
-            return None
-    except requests.exceptions.RequestException:
+    # response = requests.post(grammar_url, headers=headers, json=data)
+
+    # if response.status_code == 200:
+    #     return response.json()
+    # else:
+    response = requests.post(grammar_alt_url, headers=headers, json=data)
+    if response.status_code == 200:
+        return response.json()
+    else:
         return None
 
 
 def fetch_speller(text):
     data = {data_text: text}
-    try:
-        response = requests.post(speller_url, headers=headers, json=data, timeout=10)
-        if response.status_code == 200:
-            return response.json()
-        else:
-            return None
-    except requests.exceptions.RequestException:
+    response = requests.post(speller_url, headers=headers, json=data)
+
+    if response.status_code == 200:
+        return response.json()
+    else:
         return None
 
 

--- a/stanza-server/grammar_fetches.py
+++ b/stanza-server/grammar_fetches.py
@@ -13,25 +13,25 @@ test_grammar_url = 'https://api.tartunlp.ai/grammar/v2'
 # TODO: add back grammar_url implementation when response parsing has been fixed
 def fetch_grammar(text):
     data = {data_text: text}
-    # response = requests.post(grammar_url, headers=headers, json=data)
-
-    # if response.status_code == 200:
-    #     return response.json()
-    # else:
-    response = requests.post(grammar_alt_url, headers=headers, json=data)
-    if response.status_code == 200:
-        return response.json()
-    else:
+    try:
+        response = requests.post(grammar_alt_url, headers=headers, json=data, timeout=10)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            return None
+    except requests.exceptions.RequestException:
         return None
 
 
 def fetch_speller(text):
     data = {data_text: text}
-    response = requests.post(speller_url, headers=headers, json=data)
-
-    if response.status_code == 200:
-        return response.json()
-    else:
+    try:
+        response = requests.post(speller_url, headers=headers, json=data, timeout=10)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            return None
+    except requests.exceptions.RequestException:
         return None
 
 


### PR DESCRIPTION
## Summary

- **Fix IndexError** in `calculate_abstract_words()` and `handle_abstract_words_marking()` — estnltk's tokenizer can produce a different word count than stanza's (which filters out PUNCT/SYM tokens), causing `word_types[index]` to go out of bounds on longer texts. Added bounds checking.
- **Fix unhandled ConnectionError** in `fetch_grammar()` and `fetch_speller()` — when the grammar-worker-server is unreachable, `requests.post()` raises a `ConnectionError` instead of returning a response. Wrapped in try/except and added a 10s timeout. `generate_grammar_output()` now also handles `None` corrections gracefully.

## Root cause

The `/keerukus-sonaliigid-mitmekesisus` endpoint calls `utils.analyze()` which re-tokenizes text using estnltk. This can split compound words differently than stanza (e.g. `karjääri_mudel`), producing more tokens in `abstract_answer` than in `sonaliigid`. When iterating `abstract_answer` and indexing into `sonaliigid`, an `IndexError` is raised for longer texts.

Separately, `fetch_grammar()` and `fetch_speller()` call the grammar-worker-server without error handling. If that service is down, the uncaught `ConnectionError` crashes the entire request.

## Impact

Both issues cause **500 Internal Server Error** on the Tekstihindaja "Tasemehinnang" tab. The IndexError is reproducible in production (`elle.tlu.ee`) with sufficiently long texts.

## Test plan

- [x] Submit short text on Tekstihindaja — should return 200
- [x] Submit long text (20+ sentences) on Tekstihindaja — should return 200 (was 500 before fix)
- [ ] Verify on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)